### PR TITLE
Add image upload to main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # Detect AI
 ## for detecting AI generated text, images, audio and vedio
+
+## New Feature: Image Upload
+
+We have added a new feature to upload images on the main page. This feature allows users to upload image files, which will be processed by the server.
+
+### How to Use the Image Upload Feature
+
+1. Open the main page of the application.
+2. You will see a form to upload images.
+3. Click on the "Choose File" button to select an image file from your device.
+4. Click on the "Upload Image" button to upload the selected image.
+5. The server will process the image and return a response indicating the success of the upload.
+
+### Endpoint for Image Upload
+
+The image upload functionality is handled by the `/uploadimage/` endpoint. You can use this endpoint to upload image files programmatically.
+
+Example:
+```
+POST /uploadimage/
+Content-Type: multipart/form-data
+File: <image_file>
+```
+
+The server will respond with a JSON object containing the filename and a success message.

--- a/image/README.md
+++ b/image/README.md
@@ -1,1 +1,26 @@
 # tool for train and test image model
+
+## Image Upload Functionality
+
+We have added a new feature to upload images on the main page. This feature allows users to upload image files, which will be processed by the server.
+
+### How to Use the Image Upload Feature
+
+1. Open the main page of the application.
+2. You will see a form to upload images.
+3. Click on the "Choose File" button to select an image file from your device.
+4. Click on the "Upload Image" button to upload the selected image.
+5. The server will process the image and return a response indicating the success of the upload.
+
+### Endpoint for Image Upload
+
+The image upload functionality is handled by the `/uploadimage/` endpoint. You can use this endpoint to upload image files programmatically.
+
+Example:
+```
+POST /uploadimage/
+Content-Type: multipart/form-data
+File: <image_file>
+```
+
+The server will respond with a JSON object containing the filename and a success message.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Upload Image</title>
+</head>
+<body>
+    <h1>Upload Image</h1>
+    <form action="/uploadimage/" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept="image/*">
+        <button type="submit">Upload Image</button>
+    </form>
+</body>
+</html>

--- a/server/server.py
+++ b/server/server.py
@@ -3,6 +3,7 @@ import numpy as np
 import librosa
 from joblib import load
 import os
+from PIL import Image
 
 from fastapi import FastAPI, UploadFile, File, Request
 from fastapi.responses import HTMLResponse
@@ -53,3 +54,16 @@ async def create_upload_file(file: UploadFile = File(...)):
     # print(predictions)
 
     return {"filename": file.filename, "prediction": predictions[0]}
+
+@app.post("/uploadimage/")
+async def upload_image(file: UploadFile = File(...)):
+    contents = await file.read()
+
+    with open(f"{file.filename}", "wb") as f:
+        f.write(contents)
+    
+    image = Image.open(file.filename)
+    image = image.convert("RGB")
+    image.save(f"processed_{file.filename}")
+
+    return {"filename": file.filename, "message": "Image uploaded successfully"}


### PR DESCRIPTION
Add image upload functionality to the main page.

* **server/server.py**
  - Add a new endpoint `/uploadimage/` to handle image file uploads.
  - Use `PIL` library to process the uploaded image file.
  - Return a response indicating the success of the image upload.

* **index.html**
  - Add a form for image uploads with `enctype="multipart/form-data"`.
  - Include an input field of type `file` for image selection.
  - Add a submit button for the image upload form.

* **README.md**
  - Update the documentation to mention the new image upload feature.
  - Provide instructions on how to use the image upload functionality.
  - Mention the new endpoint `/uploadimage/` for image uploads.

* **image/README.md**
  - Add instructions for using the image upload functionality.
  - Mention the new endpoint `/uploadimage/` for image uploads.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Linghui/DeAI?shareId=03eb666f-2565-4d87-b656-d5ca05f585d1).